### PR TITLE
Fix cross-site cookie: SameSite=None for production auth

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -78,7 +78,7 @@ async def login(request: LoginRequest, response: Response):
         value=token,
         httponly=True,
         secure=True,
-        samesite="lax",
+        samesite="none",
         max_age=auth_service.ACCESS_TOKEN_EXPIRE_HOURS * 3600,
         path="/",
     )
@@ -98,7 +98,7 @@ async def login(request: LoginRequest, response: Response):
 @router.post("/logout")
 async def logout(response: Response):
     """Clear the auth cookie."""
-    response.delete_cookie(key="q2i_token", path="/")
+    response.delete_cookie(key="q2i_token", path="/", samesite="none", secure=True)
     return {"message": "Logged out"}
 
 


### PR DESCRIPTION
## Summary
- Change `SameSite=lax` to `SameSite=none` on the `q2i_token` cookie so the browser sends it on cross-origin requests
- Apply matching `SameSite=none; Secure` to the logout `delete_cookie` call
- Fixes 401 Unauthorized errors on all API calls after login in production

## Root Cause
Frontend (`red-water-0b770d310.4.azurestaticapps.net`) and backend (`api-q2i-f38387c8.azurewebsites.net`) are different origins. `SameSite=Lax` silently blocks cookies on cross-origin fetch requests, so every request after login returned 401 even though the login itself succeeded.

## Test plan
- [ ] Log in as any demo user on https://red-water-0b770d310.4.azurestaticapps.net/
- [ ] Verify no 401 errors in the browser console
- [ ] Verify queries execute successfully
- [ ] Verify logout clears the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication cookie security settings to align login and logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->